### PR TITLE
Fix for ECL

### DIFF
--- a/src/ffi/cffi-cwrap.lisp
+++ b/src/ffi/cffi-cwrap.lisp
@@ -36,11 +36,11 @@
 
 (declaim (inline fw-ptr))
 
-#+(or ccl ecl allegro)
+#+(or ccl allegro)
 (defstruct (foreign-wrapper (:conc-name #:fw-))
   (ptr #.(cffi:null-pointer) :type #.(type-of (cffi:null-pointer))))
 
-#+(or cmucl sbcl clisp)
+#+(or cmucl ecl sbcl clisp)
 (defstruct (foreign-wrapper (:conc-name #:fw-))
   (ptr (cffi:null-pointer) :type #.(type-of (cffi:null-pointer))))
 


### PR DESCRIPTION
src/ffi/cffi-cwrap.lisp uses #.(cffi:null-pointer) in the compiled code, but this cannot be done in ECL because the resulting constant cannot be externalized by the compiler.
