### PR TITLE
Introduce INIT-FREETYPE

### DIFF
--- a/src/init.lisp
+++ b/src/init.lisp
@@ -60,5 +60,10 @@ it."
 
 (export 'extract-freetype)
 
-(setf *library* (make-freetype))
+(defun init-freetype ()
+  "Initialize `*LIBRARY*`. Called when cl-freetype2 loads. If cl-freetype2 is to be used after it has been pre-loaded in an image (e.g. after cl-freetype2 has been loaded and SBCL's `SAVE-LISP-AND-DIE` has created a saved image), `INIT-FREETYPE` must be called again."
+  (setf *library* (make-freetype)))
+
+(init-freetype)
+(export 'init-freetype)
 (export '*library*)


### PR DESCRIPTION
I was recently bitten when trying to use cl-freetype2 in an image where it had been pre-loaded. My program promptly crashed with a less than helpful memory error. `*LIBRARY*` clearly must be re-initialized every time a lisp using cl-freetype2 is run. 

In order to make this fact more obvious and less clunky than asking the library user to call 

```
(setf *library* (make-freetype))
```

this patch introduces a new function, `INIT-FREETYPE`, that does exactly this.
