### PR TITLE
Make it work on FreeBSD

### DIFF
--- a/src/ffi/grovel/grovel-freetype2.lisp
+++ b/src/ffi/grovel/grovel-freetype2.lisp
@@ -1,6 +1,7 @@
 (in-package :freetype2-types)
 
 (cc-flags #+darwin "-I/opt/local/include/freetype2"
+          #+freebsd "-I/usr/local/include/freetype2"
           #-darwin "-I/usr/include/freetype2"
           #-darwin "-I/usr/include/freetype2/freetype2"
           #-darwin "-I/usr/include/freetype2/freetype"


### PR DESCRIPTION
FreeBSD ports are usually installed at /usr/local, so ft2build.h lives at:

  /usr/local/include/freetype2/ft2build.h