### PR TITLE
Fix header files include in Mac OS X

### DIFF
--- a/src/ffi/grovel/grovel-freetype2.lisp
+++ b/src/ffi/grovel/grovel-freetype2.lisp
@@ -1,6 +1,7 @@
 (in-package :freetype2-types)
 
 (cc-flags #+darwin "-I/opt/local/include/freetype2"
+          #+darwin "-I/opt/local/include/freetype2/freetype"
           #+freebsd "-I/usr/local/include/freetype2"
           #-darwin "-I/usr/include/freetype2"
           #-darwin "-I/usr/include/freetype2/freetype2"


### PR DESCRIPTION
The path of header files of FreeType is: `/opt/local/include/freetype2/freetype`. Without this path `cl-freetype2` will NOT compile success in Mac OS X.

More info related:
  OS: Mac OS X
  FreeType: FreeType v2.6.3(installed with brew)
