### PR TITLE
Make it work on FreeBSD - II

### DIFF
--- a/src/ffi/grovel/grovel-freetype2.lisp
+++ b/src/ffi/grovel/grovel-freetype2.lisp
@@ -2,6 +2,7 @@
 
 (cc-flags #+darwin "-I/opt/local/include/freetype2"
           #+freebsd "-I/usr/local/include/freetype2"
+          #+freebsd "-I/usr/local/include/freetype2/freetype"
           #+(and windows x86-64) "-I/mingw64/include/freetype2"
           #+(and windows x86-64) "-Ic:/msys64/mingw64/include/freetype2"
           #+(and windows x86) "-I/mingw32/include/freetype2"


### PR DESCRIPTION
Since the project references header files which live in `freetype` subdirectory, need to add another include path, otherwise we get this:

    In file included from $HOME/.cache/common-lisp/sbcl-1.4.4-bsd-x64/$HOME/quicklisp/dists/quicklisp/software/cl-freetype2-20170830-git/src/ffi/grovel/grovel-freetype2__grovel.c:6:
    $HOME/quicklisp/dists/quicklisp/software/cl-freetype2-20170830-git/src/ffi/grovel/grovel-freetype.h:5:10: fatal error: 
          'ftsystem.h' file not found
    #include <ftsystem.h>
             ^~~~~~~~~~~~
    1 error generated.

HTH