### PR TITLE
Use pkg-config (when available) to detect -I include paths

### DIFF
--- a/src/ffi/grovel/grovel-freetype.h
+++ b/src/ffi/grovel/grovel-freetype.h
@@ -2,7 +2,7 @@
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
-#include <ftsystem.h>
-#include <fttypes.h>
-#include <ftlist.h>
-#include <ftimage.h>
+#include <freetype/ftsystem.h>
+#include <freetype/fttypes.h>
+#include <freetype/ftlist.h>
+#include <freetype/ftimage.h>

--- a/src/ffi/grovel/grovel-freetype2.lisp
+++ b/src/ffi/grovel/grovel-freetype2.lisp
@@ -15,6 +15,10 @@
           #-darwin "-I/usr/include/freetype2/freetype"
           #-darwin "-I/usr/include/freetype")
 
+;; Use pkg-config (if available) to resolve include paths.
+;; (The hard-coded paths above don't apply on all systems.)
+(pkg-config-cflags "freetype2" :optional t)
+
 (include "grovel-freetype.h")
 
 (constant (+version-major+ "FREETYPE_MAJOR"))


### PR DESCRIPTION
Use the PKG-CONFIG-CFLAGS feature of CL-CFFI to automatically detect the correct include path for freetype. Use `:OPTIONAL T` to ignore this when it doesn't work and fall back to the hard-coded paths.

This is a portability fix and in particular it unbreaks cl-freetype2 for the Nix package manager and NixOS Linux distribution.

Changed include patterns from `<ftsystem.h>` to `<freetype/ftsystem.h>` which may cause complications but seems correct (and was necessary to work in my environment.)