### PR TITLE
Added :target-mono load-flags, corresponding to FT_LOAD_TARGET_MONO.

### DIFF
--- a/src/ffi/cffi-defs.lisp
+++ b/src/ffi/cffi-defs.lisp
@@ -24,6 +24,7 @@
   :monochrome :linear-design
 
   (:no-autohint #x8000)
+  (:target-mono #x20000)
 
   ;; Only valid for ft-get-advance / ft-get-advances
   (:fast-advance-only #x20000000))


### PR DESCRIPTION
I noticed there was an enum missing from the load-flags bitfield, so I have added it.